### PR TITLE
Revert "chore: Rename crate to nss"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -160,7 +160,7 @@ dependencies = [
 
 [[package]]
 name = "nss-rs"
-version = "0.3.0"
+version = "0.8.0"
 dependencies = [
  "bindgen",
  "enum-map",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -159,8 +159,8 @@ dependencies = [
 ]
 
 [[package]]
-name = "nss"
-version = "0.8.0"
+name = "nss-rs"
+version = "0.3.0"
 dependencies = [
  "bindgen",
  "enum-map",
@@ -333,7 +333,7 @@ name = "test-fixture"
 version = "0.1.0"
 dependencies = [
  "log",
- "nss",
+ "nss-rs",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
-name = "nss"
-version = "0.8.0"
+name = "nss-rs"
+version = "0.3.0"
 authors = ["Martin Thomson <mt@lowentropy.net>", "Andy Leiserson <aleiserson@mozilla.com>", "John M. Schanck <jschanck@mozilla.com>", "Benjamin Beurdouche <beurdouche@mozilla.com>", "Anna Weine <anna.weine@mozilla.com>"]
 categories = ["network-programming", "web-programming"]
 keywords = ["nss", "crypto", "mozilla", "firefox"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nss-rs"
-version = "0.3.0"
+version = "0.8.0"
 authors = ["Martin Thomson <mt@lowentropy.net>", "Andy Leiserson <aleiserson@mozilla.com>", "John M. Schanck <jschanck@mozilla.com>", "Benjamin Beurdouche <beurdouche@mozilla.com>", "Anna Weine <anna.weine@mozilla.com>"]
 categories = ["network-programming", "web-programming"]
 keywords = ["nss", "crypto", "mozilla", "firefox"]

--- a/src/sig.rs
+++ b/src/sig.rs
@@ -20,7 +20,7 @@
 // CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 // use crate::Result;
-use nss::ec::{Curve, PublicKey};
+use nss_rs::ec::{Curve, PublicKey};
 use nss_rs::HashAlgorithm;
 
 /// A signature verification algorithm.

--- a/src/sig.rs
+++ b/src/sig.rs
@@ -21,7 +21,7 @@
 
 // use crate::Result;
 use nss::ec::{Curve, PublicKey};
-use nss::HashAlgorithm;
+use nss_rs::HashAlgorithm;
 
 /// A signature verification algorithm.
 pub struct SignatureAlgorithm {

--- a/test-fixture/Cargo.toml
+++ b/test-fixture/Cargo.toml
@@ -8,10 +8,10 @@ license = "MIT/Apache-2.0"
 
 [dependencies]
 log = {version = "0.4.0", default-features = false}
-nss = { path = "../" }
+nss-rs = { path = "../" }
 
 [features]
-bench = ["nss/bench"]
+bench = ["nss-rs/bench"]
 disable-random = []
 
 [package.metadata.cargo-machete]

--- a/test-fixture/src/lib.rs
+++ b/test-fixture/src/lib.rs
@@ -11,7 +11,7 @@ use std::{
     time::{Duration, Instant},
 };
 
-use nss::{init_db, AntiReplay};
+use nss_rs::{init_db, AntiReplay};
 
 /// The path for the database used in tests.
 ///

--- a/tests/aead.rs
+++ b/tests/aead.rs
@@ -7,7 +7,7 @@
 #![warn(clippy::pedantic)]
 #![cfg(not(feature = "disable-encryption"))]
 
-use nss::{
+use nss_rs::{
     RecordProtection,
     constants::{Cipher, TLS_AES_128_GCM_SHA256, TLS_VERSION_1_3},
     hkdf,

--- a/tests/agent.rs
+++ b/tests/agent.rs
@@ -3,7 +3,7 @@
 
 use std::ffi::CStr;
 
-use nss::{
+use nss_rs::{
     AuthenticationStatus, Client, Error, HandshakeState, Res, SecretAgentPreInfo, Server,
     TLS_AES_128_GCM_SHA256, TLS_CHACHA20_POLY1305_SHA256, TLS_GRP_EC_SECP256R1, TLS_GRP_EC_X25519,
     TLS_SIG_ECDSA_SECP256R1_SHA256, TLS_VERSION_1_3, ZeroRttCheckResult, ZeroRttChecker,
@@ -151,7 +151,7 @@ fn ocsp_stapling_and_signed_cert_timestamps() {
     fixture_init();
     let mut client = Client::new("server.example", true).expect("should create client");
     client
-        .set_option(nss::Opt::SignedCertificateTimestamps, true)
+        .set_option(nss_rs::Opt::SignedCertificateTimestamps, true)
         .unwrap();
     let ocsp_response = b"fake ocsp response";
     let scts = b"fake signed certificate timestamps";

--- a/tests/ext.rs
+++ b/tests/ext.rs
@@ -7,7 +7,7 @@
 use std::{cell::RefCell, rc::Rc};
 
 use handshake::forward_records;
-use nss::{
+use nss_rs::{
     AuthenticationStatus, Client, Error, HandshakeState, Server,
     constants::{HandshakeMessage, TLS_HS_CLIENT_HELLO, TLS_HS_ENCRYPTED_EXTENSIONS},
     ext::{ExtensionHandler, ExtensionHandlerResult, ExtensionWriterResult},

--- a/tests/handshake.rs
+++ b/tests/handshake.rs
@@ -9,7 +9,7 @@
 use std::{mem, time::Instant};
 
 use log::info;
-use nss::{
+use nss_rs::{
     AntiReplay, AuthenticationStatus, Client, HandshakeState, RecordList, Res, ResumptionToken,
     SecretAgent, Server, ZeroRttCheckResult, ZeroRttChecker,
 };

--- a/tests/hkdf.rs
+++ b/tests/hkdf.rs
@@ -4,7 +4,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use nss::{
+use nss_rs::{
     SymKey,
     constants::{
         Cipher, TLS_AES_128_GCM_SHA256, TLS_AES_256_GCM_SHA384, TLS_CHACHA20_POLY1305_SHA256,

--- a/tests/hp.rs
+++ b/tests/hp.rs
@@ -4,7 +4,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use nss::{
+use nss_rs::{
     constants::{
         Cipher, TLS_AES_128_GCM_SHA256, TLS_AES_256_GCM_SHA384, TLS_CHACHA20_POLY1305_SHA256,
         TLS_VERSION_1_3,

--- a/tests/init.rs
+++ b/tests/init.rs
@@ -11,11 +11,11 @@
 // a different version of init_db.  That causes explosions as they get
 // different versions of the Once instance they use and they initialize NSS
 // twice, probably likely in parallel.  That doesn't work out well.
-use nss::assert_initialized;
+use nss_rs::assert_initialized;
 #[cfg(nss_nodb)]
-use nss::init;
+use nss_rs::init;
 #[cfg(not(nss_nodb))]
-use nss::init_db;
+use nss_rs::init_db;
 
 // Pull in the NSS internals so that we can ask NSS if it thinks that
 // it is properly initialized.
@@ -24,18 +24,18 @@ use nss::init_db;
     dead_code,
     reason = "Code is bindgen-generated."
 )]
-mod nss_init {
-    use nss::nss_prelude::*;
+mod nss {
+    use nss_rs::nss_prelude::*;
     include!(concat!(env!("OUT_DIR"), "/nss_init.rs"));
 }
 
 #[cfg(nss_nodb)]
 #[test]
 fn init_nodb() {
-    nss::init().unwrap();
+    nss_rs::init().unwrap();
     assert_initialized();
     unsafe {
-        assert_ne!(nss_init::NSS_IsInitialized(), 0);
+        assert_ne!(nss::NSS_IsInitialized(), 0);
     }
 }
 
@@ -45,6 +45,6 @@ fn init_withdb() {
     init_db(::test_fixture::NSS_DB_PATH).unwrap();
     assert_initialized();
     unsafe {
-        assert_ne!(nss_init::NSS_IsInitialized(), 0);
+        assert_ne!(nss::NSS_IsInitialized(), 0);
     }
 }

--- a/tests/init.rs
+++ b/tests/init.rs
@@ -24,7 +24,7 @@ use nss_rs::init_db;
     dead_code,
     reason = "Code is bindgen-generated."
 )]
-mod nss {
+mod nss_init {
     use nss_rs::nss_prelude::*;
     include!(concat!(env!("OUT_DIR"), "/nss_init.rs"));
 }
@@ -35,7 +35,7 @@ fn init_nodb() {
     nss_rs::init().unwrap();
     assert_initialized();
     unsafe {
-        assert_ne!(nss::NSS_IsInitialized(), 0);
+        assert_ne!(nss_init::NSS_IsInitialized(), 0);
     }
 }
 
@@ -45,6 +45,6 @@ fn init_withdb() {
     init_db(::test_fixture::NSS_DB_PATH).unwrap();
     assert_initialized();
     unsafe {
-        assert_ne!(nss::NSS_IsInitialized(), 0);
+        assert_ne!(nss_init::NSS_IsInitialized(), 0);
     }
 }

--- a/tests/selfencrypt.rs
+++ b/tests/selfencrypt.rs
@@ -7,7 +7,7 @@
 #![cfg(not(feature = "disable-encryption"))]
 #![cfg(test)]
 
-use nss::{
+use nss_rs::{
     Error,
     constants::{TLS_AES_128_GCM_SHA256, TLS_VERSION_1_3},
     init,


### PR DESCRIPTION
Reverts mozilla/nss-rs#35. See mozilla/nss-rs#27. The version can stay the same, since we will need to go back to versions > 0.7.1 when we go back to "nss" (see original PR)