### PR TITLE
feat: remove `Rc<RefCell<Context>>` from `hp::Key`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -160,7 +160,7 @@ dependencies = [
 
 [[package]]
 name = "nss-rs"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "bindgen",
  "enum-map",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nss-rs"
-version = "0.9.1"
+version = "0.10.0"
 authors = ["Martin Thomson <mt@lowentropy.net>", "Andy Leiserson <aleiserson@mozilla.com>", "John M. Schanck <jschanck@mozilla.com>", "Benjamin Beurdouche <beurdouche@mozilla.com>", "Anna Weine <anna.weine@mozilla.com>"]
 categories = ["network-programming", "web-programming"]
 keywords = ["nss", "crypto", "mozilla", "firefox"]

--- a/src/hp.rs
+++ b/src/hp.rs
@@ -49,31 +49,19 @@ fn make_aes_ctx(key: &SymKey) -> Res<Context> {
             SECItemBorrowed::make_empty().as_ref(),
         )
     })
-    .or(Err(Error::CipherInit))
+    .map_err(|_| Error::CipherInit)
 }
 
 pub enum Key {
     /// AES-ECB header-protection context.  `PK11_CloneContext` is not supported for
-    /// AES-ECB, so we store the `SymKey` and recreate `ctx` lazily: `mask` initialises
-    /// it on first use when `ctx` is `None`.
+    /// AES-ECB, so the `SymKey` is stored alongside `ctx` to enable duplication via
+    /// `try_clone`.
     #[non_exhaustive]
-    Aes { ctx: Option<Context>, key: SymKey },
+    Aes { ctx: Context, key: SymKey },
     /// The `ChaCha20` mask invokes `PK11_Encrypt` on each call because the counter
     /// and nonce change per invocation.
     #[non_exhaustive]
     Chacha(SymKey),
-}
-
-impl Clone for Key {
-    fn clone(&self) -> Self {
-        match self {
-            Self::Aes { key, .. } => Self::Aes {
-                ctx: None,
-                key: key.clone(),
-            },
-            Self::Chacha(k) => Self::Chacha(k.clone()),
-        }
-    }
 }
 
 impl Debug for Key {
@@ -125,7 +113,7 @@ impl Key {
 
         let res = match cipher {
             TLS_AES_128_GCM_SHA256 | TLS_AES_256_GCM_SHA384 => {
-                let ctx = Some(make_aes_ctx(&key)?);
+                let ctx = make_aes_ctx(&key)?;
                 Self::Aes { ctx, key }
             }
             TLS_CHACHA20_POLY1305_SHA256 => Self::Chacha(key),
@@ -146,6 +134,22 @@ impl Key {
         }
     }
 
+    /// Duplicate this key, creating a new independent instance.
+    ///
+    /// # Errors
+    ///
+    /// Errors if NSS context creation fails for AES keys.
+    pub fn try_clone(&self) -> Res<Self> {
+        match self {
+            Self::Aes { key, .. } => {
+                let key = key.clone();
+                let ctx = make_aes_ctx(&key)?;
+                Ok(Self::Aes { ctx, key })
+            }
+            Self::Chacha(k) => Ok(Self::Chacha(k.clone())),
+        }
+    }
+
     /// Generate a header protection mask for QUIC.
     ///
     /// # Errors
@@ -154,21 +158,17 @@ impl Key {
     ///
     /// # Panics
     ///
-    /// When the mechanism for our key is not supported.
-    pub fn mask(&mut self, sample: &[u8; Self::SAMPLE_SIZE]) -> Res<[u8; Self::SAMPLE_SIZE]> {
+    /// In debug builds, if NSS returns an unexpected output length.
+    pub fn mask(&self, sample: &[u8; Self::SAMPLE_SIZE]) -> Res<[u8; Self::SAMPLE_SIZE]> {
         let mut output = [0; Self::SAMPLE_SIZE];
 
         match self {
-            Self::Aes { ctx, key } => {
-                let ctx = if let Some(c) = ctx {
-                    c
-                } else {
-                    ctx.insert(make_aes_ctx(key)?)
-                };
+            Self::Aes { ctx, .. } => {
                 let mut output_len: c_int = 0;
-                // SAFETY: `Deref` on `Context` yields a copy of the raw `*mut PK11Context`;
-                // no Rust reference to the pointee is created, and `&mut self` guarantees
-                // exclusive access to this `Key`.
+                // SAFETY: `Deref` on `Context` copies the raw `*mut PK11Context` pointer
+                // value; no Rust reference to the pointee is created.  `Key` contains raw
+                // pointers (`!Sync`), so concurrent invocations are impossible, and
+                // AES-ECB full-block operations retain no inter-call state in the context.
                 secstatus_to_res(unsafe {
                     PK11_CipherOp(
                         **ctx,

--- a/src/hp.rs
+++ b/src/hp.rs
@@ -40,8 +40,7 @@ experimental_api!(SSL_HkdfExpandLabelWithMech(
 ));
 
 /// Creates an AES-ECB `PK11Context` from a `SymKey`.
-/// `PK11_CloneContext` is not supported for AES-ECB, so `Clone` stores the `SymKey`
-/// and recreates the context on first use via `mask`.
+fn make_aes_ctx(key: &SymKey) -> Res<Context> {
 fn make_aes_ctx(key: &SymKey) -> Res<Context> {
     Context::from_ptr(unsafe {
         PK11_CreateContextBySymKey(

--- a/src/hp.rs
+++ b/src/hp.rs
@@ -5,12 +5,10 @@
 // except according to those terms.
 
 use std::{
-    cell::RefCell,
     convert::TryFrom as _,
     fmt::{self, Debug},
     os::raw::{c_char, c_int, c_uint},
     ptr::{null, null_mut},
-    rc::Rc,
 };
 
 use pkcs11_bindings::{CKA_ENCRYPT, CKM_AES_ECB, CKM_CHACHA20};
@@ -41,16 +39,41 @@ experimental_api!(SSL_HkdfExpandLabelWithMech(
     secret: *mut *mut PK11SymKey,
 ));
 
-#[derive(Clone)]
+/// Creates an AES-ECB `PK11Context` from a `SymKey`.
+/// `PK11_CloneContext` is not supported for AES-ECB, so `Clone` stores the `SymKey`
+/// and recreates the context on first use via `mask`.
+fn make_aes_ctx(key: &SymKey) -> Res<Context> {
+    Context::from_ptr(unsafe {
+        PK11_CreateContextBySymKey(
+            CK_MECHANISM_TYPE::from(CKM_AES_ECB),
+            CK_ATTRIBUTE_TYPE::from(CKA_ENCRYPT),
+            **key,
+            SECItemBorrowed::make_empty().as_ref(),
+        )
+    })
+    .or(Err(Error::CipherInit))
+}
+
 pub enum Key {
-    /// An AES encryption context.
-    /// Note: as we need to clone this object, we clone the pointer and
-    /// track references using `Rc`.  `PK11Context` can't be used with `PK11_CloneContext`
-    /// as that is not supported for these contexts.
-    Aes(Rc<RefCell<Context>>),
-    /// The `ChaCha20` mask has to invoke a new `PK11_Encrypt` every time as it needs to
-    /// change the counter and nonce on each invocation.
+    /// AES-ECB header-protection context.  `PK11_CloneContext` is not supported for
+    /// AES-ECB, so we store the `SymKey` and recreate `ctx` lazily on first use after
+    /// a clone.  `ctx` is `None` only between `clone()` and the first call to `mask`.
+    Aes { ctx: Option<Context>, key: SymKey },
+    /// The `ChaCha20` mask invokes `PK11_Encrypt` on each call because the counter
+    /// and nonce change per invocation.
     Chacha(SymKey),
+}
+
+impl Clone for Key {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Aes { key, .. } => Self::Aes {
+                ctx: None,
+                key: key.clone(),
+            },
+            Self::Chacha(k) => Self::Chacha(k.clone()),
+        }
+    }
 }
 
 impl Debug for Key {
@@ -72,8 +95,6 @@ impl Key {
     ///
     /// When `cipher` is not known to this code.
     pub fn extract(version: Version, cipher: Cipher, prk: &SymKey, label: &str) -> Res<Self> {
-        const ZERO: &[u8] = &[0; 12];
-
         let l = label.as_bytes();
         let mut secret: *mut PK11SymKey = null_mut();
 
@@ -104,17 +125,8 @@ impl Key {
 
         let res = match cipher {
             TLS_AES_128_GCM_SHA256 | TLS_AES_256_GCM_SHA384 => {
-                let context_ptr = unsafe {
-                    PK11_CreateContextBySymKey(
-                        mech,
-                        CK_ATTRIBUTE_TYPE::from(CKA_ENCRYPT),
-                        *key,
-                        SECItemBorrowed::wrap(&ZERO[..0])?.as_ref(), /* Borrow a zero-length
-                                                                      * slice of ZERO. */
-                    )
-                };
-                let context = Context::from_ptr(context_ptr).or(Err(Error::CipherInit))?;
-                Self::Aes(Rc::new(RefCell::new(context)))
+                let ctx = Some(make_aes_ctx(&key)?);
+                Self::Aes { ctx, key }
             }
             TLS_CHACHA20_POLY1305_SHA256 => Self::Chacha(key),
             _ => unreachable!(),
@@ -129,7 +141,7 @@ impl Key {
 
     const fn block_size(&self) -> usize {
         match self {
-            Self::Aes(_) => 16,
+            Self::Aes { .. } => 16,
             Self::Chacha(_) => 64,
         }
     }
@@ -143,15 +155,21 @@ impl Key {
     /// # Panics
     ///
     /// When the mechanism for our key is not supported.
-    pub fn mask(&self, sample: &[u8; Self::SAMPLE_SIZE]) -> Res<[u8; Self::SAMPLE_SIZE]> {
+    pub fn mask(&mut self, sample: &[u8; Self::SAMPLE_SIZE]) -> Res<[u8; Self::SAMPLE_SIZE]> {
         let mut output = [0; Self::SAMPLE_SIZE];
 
         match self {
-            Self::Aes(context) => {
+            Self::Aes { ctx, key } => {
+                if ctx.is_none() {
+                    *ctx = Some(make_aes_ctx(key)?);
+                }
+                let ctx = ctx.as_ref().expect("context initialized above");
                 let mut output_len: c_int = 0;
+                // SAFETY: AES-ECB is stateless — no IV or counter is mutated between
+                // calls — so using a raw pointer from &ctx is sound.
                 secstatus_to_res(unsafe {
                     PK11_CipherOp(
-                        **context.borrow_mut(),
+                        **ctx,
                         output.as_mut_ptr(),
                         &raw mut output_len,
                         c_int::try_from(output.len())?,

--- a/src/hp.rs
+++ b/src/hp.rs
@@ -56,8 +56,8 @@ fn make_aes_ctx(key: &SymKey) -> Res<Context> {
 
 pub enum Key {
     /// AES-ECB header-protection context.  `PK11_CloneContext` is not supported for
-    /// AES-ECB, so we store the `SymKey` and recreate `ctx` lazily on first use after
-    /// a clone.  `ctx` is `None` only between `clone()` and the first call to `mask`.
+    /// AES-ECB, so we store the `SymKey` and recreate `ctx` lazily: `mask` initialises
+    /// it on first use when `ctx` is `None`.
     Aes { ctx: Option<Context>, key: SymKey },
     /// The `ChaCha20` mask invokes `PK11_Encrypt` on each call because the counter
     /// and nonce change per invocation.
@@ -160,13 +160,15 @@ impl Key {
 
         match self {
             Self::Aes { ctx, key } => {
-                if ctx.is_none() {
-                    *ctx = Some(make_aes_ctx(key)?);
-                }
-                let ctx = ctx.as_ref().expect("context initialized above");
+                let ctx = if let Some(c) = ctx {
+                    c
+                } else {
+                    ctx.insert(make_aes_ctx(key)?)
+                };
                 let mut output_len: c_int = 0;
-                // SAFETY: AES-ECB is stateless — no IV or counter is mutated between
-                // calls — so using a raw pointer from &ctx is sound.
+                // SAFETY: `Deref` on `Context` yields a copy of the raw `*mut PK11Context`;
+                // no Rust reference to the pointee is created, and `&mut self` guarantees
+                // exclusive access to this `Key`.
                 secstatus_to_res(unsafe {
                     PK11_CipherOp(
                         **ctx,

--- a/src/hp.rs
+++ b/src/hp.rs
@@ -41,7 +41,6 @@ experimental_api!(SSL_HkdfExpandLabelWithMech(
 
 /// Creates an AES-ECB `PK11Context` from a `SymKey`.
 fn make_aes_ctx(key: &SymKey) -> Res<Context> {
-fn make_aes_ctx(key: &SymKey) -> Res<Context> {
     Context::from_ptr(unsafe {
         PK11_CreateContextBySymKey(
             CK_MECHANISM_TYPE::from(CKM_AES_ECB),
@@ -57,9 +56,11 @@ pub enum Key {
     /// AES-ECB header-protection context.  `PK11_CloneContext` is not supported for
     /// AES-ECB, so we store the `SymKey` and recreate `ctx` lazily: `mask` initialises
     /// it on first use when `ctx` is `None`.
+    #[non_exhaustive]
     Aes { ctx: Option<Context>, key: SymKey },
     /// The `ChaCha20` mask invokes `PK11_Encrypt` on each call because the counter
     /// and nonce change per invocation.
+    #[non_exhaustive]
     Chacha(SymKey),
 }
 

--- a/tests/hp.rs
+++ b/tests/hp.rs
@@ -21,11 +21,11 @@ fn make_hp(cipher: Cipher) -> hp::Key {
 }
 
 fn hp_test(cipher: Cipher, expected: &[u8]) {
-    let hp = make_hp(cipher);
+    let mut hp = make_hp(cipher);
     let mask = hp.mask(&[0; 16]).expect("should produce a mask");
     assert_eq!(mask, expected, "first invocation should be correct");
 
-    let hp2 = hp.clone();
+    let mut hp2 = hp.clone();
     let mask = hp2.mask(&[0; 16]).expect("clone produces mask");
     assert_eq!(mask, expected, "clone should produce the same mask");
 

--- a/tests/hp.rs
+++ b/tests/hp.rs
@@ -21,11 +21,11 @@ fn make_hp(cipher: Cipher) -> hp::Key {
 }
 
 fn hp_test(cipher: Cipher, expected: &[u8]) {
-    let mut hp = make_hp(cipher);
+    let hp = make_hp(cipher);
     let mask = hp.mask(&[0; 16]).expect("should produce a mask");
     assert_eq!(mask, expected, "first invocation should be correct");
 
-    let mut hp2 = hp.clone();
+    let hp2 = hp.try_clone().expect("try_clone succeeds");
     let mask = hp2.mask(&[0; 16]).expect("clone produces mask");
     assert_eq!(mask, expected, "clone should produce the same mask");
 


### PR DESCRIPTION
Replace `Aes(Rc<RefCell<Context>>)` with `Aes { ctx: Option<Context>, key: SymKey }`, eliminating the `RefCell::borrow_mut` overhead on every call to `Key::mask`.

`PK11_CloneContext` is not supported for AES-ECB contexts, so `Clone` stores the `SymKey` (via `PK11_ReferenceSymKey`, O(1)) and sets `ctx` to `None`. The context is recreated lazily on the first call to `mask` after a clone, surfacing any NSS error there rather than panicking in `Clone`.

`mask` now takes `&mut self`; neqo will need a corresponding update.