### PR TITLE
feat: increase `RandomCache` size from 256 to 4096 bytes

### DIFF
--- a/src/p11.rs
+++ b/src/p11.rs
@@ -363,7 +363,7 @@ struct RandomCache {
 }
 
 impl RandomCache {
-    const SIZE: usize = 256;
+    const SIZE: usize = 4096;
     const CUTOFF: usize = 32;
 
     // Const constructor for compile-time initialization in thread_local!.


### PR DESCRIPTION
`random::<N>()` refills a thread-local cache via `PK11_GenerateRandom` (SHA-256 DRBG) each time the cache is exhausted. That can still cause measurable overheads if a lot of random bytes are needed.