### PR TITLE
fix: export `AEAD_NULL_TAG` with `disable-encryption` feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -160,7 +160,7 @@ dependencies = [
 
 [[package]]
 name = "nss-rs"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "bindgen",
  "enum-map",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nss-rs"
-version = "0.9.0"
+version = "0.9.1"
 authors = ["Martin Thomson <mt@lowentropy.net>", "Andy Leiserson <aleiserson@mozilla.com>", "John M. Schanck <jschanck@mozilla.com>", "Benjamin Beurdouche <beurdouche@mozilla.com>", "Anna Weine <anna.weine@mozilla.com>"]
 categories = ["network-programming", "web-programming"]
 keywords = ["nss", "crypto", "mozilla", "firefox"]

--- a/src/aead.rs
+++ b/src/aead.rs
@@ -6,6 +6,8 @@
 
 use std::{os::raw::c_int, ptr::null_mut};
 
+#[cfg(feature = "disable-encryption")]
+pub use recprot::AEAD_NULL_TAG;
 pub use recprot::RecordProtection;
 
 use crate::{


### PR DESCRIPTION
neqo needs it