### PR TITLE
fix: runtime `NSS_DB_PATH` and `Once`-guarded `fixture_init`

### DIFF
--- a/.github/actions/check-android/action.yml
+++ b/.github/actions/check-android/action.yml
@@ -89,7 +89,7 @@ runs:
           adb push "$test" "$TMP/"
           adb shell chmod +x "$TMP/$(basename "$test")"
           # See https://unix.stackexchange.com/a/451140/409256
-          adb shell "CARGO_TERM_COLOR=always RUST_BACKTRACE=1 LD_LIBRARY_PATH=$TMP/lib NSS_DB_PATH=$TMP/db API_LEVEL=$API_LEVEL $TMP/$(basename "$test") || echo _FAIL_" 2>&1 | tee output
+          adb shell "CARGO_TERM_COLOR=always RUST_BACKTRACE=1 LD_LIBRARY_PATH=$TMP/lib TEST_FIXTURE_DB=$TMP/db API_LEVEL=$API_LEVEL $TMP/$(basename "$test") || echo _FAIL_" 2>&1 | tee output
           grep _FAIL_ output > /dev/null && any_failures=1
         done
         exit $any_failures

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -160,7 +160,7 @@ dependencies = [
 
 [[package]]
 name = "nss-rs"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "bindgen",
  "enum-map",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nss-rs"
-version = "0.10.0"
+version = "0.10.1"
 authors = ["Martin Thomson <mt@lowentropy.net>", "Andy Leiserson <aleiserson@mozilla.com>", "John M. Schanck <jschanck@mozilla.com>", "Benjamin Beurdouche <beurdouche@mozilla.com>", "Anna Weine <anna.weine@mozilla.com>"]
 categories = ["network-programming", "web-programming"]
 keywords = ["nss", "crypto", "mozilla", "firefox"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,7 +38,6 @@ mod ssl;
 pub mod time;
 
 use std::{
-    env,
     ffi::CString,
     path::{Path, PathBuf},
     ptr::null,
@@ -189,15 +188,15 @@ pub fn init() -> Res<()> {
     res.as_ref().map(|_| ()).map_err(Clone::clone)
 }
 
+/// The path to the default NSS database used for testing.
+pub const TEST_FIXTURE_DB: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/test-fixture/db");
+
 /// Initialize with a database.
 ///
 /// # Errors
 ///
 /// If NSS cannot be initialized.
 pub fn init_db<P: Into<PathBuf>>(dir: P) -> Res<()> {
-    // Allow overriding the NSS database path with an environment variable.
-    let dir =
-        env::var("NSS_DB_PATH").unwrap_or(dir.into().to_str().ok_or(Error::Internal)?.to_string());
     let res = INITIALIZED.get_or_init(|| init_once(Some(dir.into())));
     res.as_ref().map(|_| ()).map_err(Clone::clone)
 }

--- a/src/pbkdf2.rs
+++ b/src/pbkdf2.rs
@@ -73,10 +73,13 @@ pub fn pbkdf2(
 
 #[cfg(test)]
 mod tests {
+    use test_fixture::fixture_init;
+
     use super::*;
 
     #[test]
     fn rfc_7914_vector_1() {
+        fixture_init();
         // RFC 7914 §11 provides PBKDF2-HMAC-SHA256 vectors. Using a common one:
         // password="password", salt="salt", iter=1, dkLen=32.
         let dk = pbkdf2(&HmacAlgorithm::HMAC_SHA2_256, b"password", b"salt", 1, 32).unwrap();
@@ -90,6 +93,7 @@ mod tests {
 
     #[test]
     fn rfc_7914_vector_iter_2() {
+        fixture_init();
         let dk = pbkdf2(&HmacAlgorithm::HMAC_SHA2_256, b"password", b"salt", 2, 32).unwrap();
         let expected = [
             0xae, 0x4d, 0x0c, 0x95, 0xaf, 0x6b, 0x46, 0xd3, 0x2d, 0x0a, 0xdf, 0xf9, 0x28, 0xf0,
@@ -101,6 +105,7 @@ mod tests {
 
     #[test]
     fn pbkdf2_sha384_vector() {
+        fixture_init();
         let dk = pbkdf2(&HmacAlgorithm::HMAC_SHA2_384, b"password", b"salt", 1, 20).unwrap();
         let expected = [
             0xc0, 0xe1, 0x4f, 0x06, 0xe4, 0x9e, 0x32, 0xd7, 0x3f, 0x9f, 0x52, 0xdd, 0xf1, 0xd0,
@@ -111,6 +116,7 @@ mod tests {
 
     #[test]
     fn pbkdf2_sha512_vector() {
+        fixture_init();
         let dk = pbkdf2(&HmacAlgorithm::HMAC_SHA2_512, b"password", b"salt", 1, 20).unwrap();
         let expected = [
             0x86, 0x7f, 0x70, 0xcf, 0x1a, 0xde, 0x02, 0xcf, 0xf3, 0x75, 0x25, 0x99, 0xa3, 0xa5,
@@ -121,6 +127,7 @@ mod tests {
 
     #[test]
     fn deterministic_across_calls() {
+        fixture_init();
         let a = pbkdf2(
             &HmacAlgorithm::HMAC_SHA2_256,
             b"hello",
@@ -142,6 +149,7 @@ mod tests {
 
     #[test]
     fn different_salt_different_key() {
+        fixture_init();
         let a = pbkdf2(
             &HmacAlgorithm::HMAC_SHA2_256,
             b"hello",

--- a/test-fixture/src/lib.rs
+++ b/test-fixture/src/lib.rs
@@ -8,22 +8,32 @@
 
 use std::{
     cell::OnceCell,
+    path::PathBuf,
+    sync::Once,
     time::{Duration, Instant},
 };
 
-use nss_rs::{init_db, AntiReplay};
+use nss_rs::{init_db, AntiReplay, TEST_FIXTURE_DB};
 
-/// The path for the database used in tests.
+/// Returns the path to the NSS test fixture database.
 ///
-/// Initialized via the `NSS_DB_PATH` environment variable. If that is not set,
-/// it defaults to the `db` directory in the current crate. If the environment
-/// variable is set to `$ARGV0`, it will be initialized to the directory of the
-/// current executable.
-pub const NSS_DB_PATH: &str = if let Some(dir) = option_env!("NSS_DB_PATH") {
-    dir
-} else {
-    concat!(env!("CARGO_MANIFEST_DIR"), "/db")
-};
+/// Reads the `TEST_FIXTURE_DB` environment variable if set, falling back to
+/// [`TEST_FIXTURE_DB`].  If the value is `$ARGV0`, returns the directory of
+/// the current executable instead.
+#[must_use]
+pub fn db_path() -> PathBuf {
+    match std::env::var("TEST_FIXTURE_DB").as_deref() {
+        Ok("$ARGV0") => {
+            let mut exe = std::env::current_exe().unwrap();
+            exe.pop();
+            exe
+        }
+        Ok(path) => PathBuf::from(path),
+        Err(_) => PathBuf::from(TEST_FIXTURE_DB),
+    }
+}
+
+static FIXTURE_INIT: Once = Once::new();
 
 /// Initialize the test fixture.  Only call this if you aren't also calling a
 /// fixture function that depends on setup.  Other functions in the fixture
@@ -34,14 +44,9 @@ pub const NSS_DB_PATH: &str = if let Some(dir) = option_env!("NSS_DB_PATH") {
 /// When the NSS initialization fails.
 #[allow(dead_code)]
 pub fn fixture_init() {
-    if NSS_DB_PATH == "$ARGV0" {
-        let mut current_exe = std::env::current_exe().unwrap();
-        current_exe.pop();
-        let nss_db_path = current_exe.to_str().unwrap();
-        init_db(nss_db_path).unwrap();
-    } else {
-        init_db(NSS_DB_PATH).unwrap();
-    }
+    FIXTURE_INIT.call_once(|| {
+        init_db(db_path()).unwrap();
+    });
 }
 
 // This needs to be > 2ms to avoid it being rounded to zero.

--- a/tests/init.rs
+++ b/tests/init.rs
@@ -42,7 +42,7 @@ fn init_nodb() {
 #[cfg(not(nss_nodb))]
 #[test]
 fn init_withdb() {
-    init_db(::test_fixture::NSS_DB_PATH).unwrap();
+    init_db(::test_fixture::db_path()).unwrap();
     assert_initialized();
     unsafe {
         assert_ne!(nss_init::NSS_IsInitialized(), 0);


### PR DESCRIPTION
Replace compile-time `option_env!` with `std::env::var` at runtime, wrap `fixture_init` in `std::sync::Once`, move the env-var override out of `init_db` and into `fixture_init`, and add `fixture_init()` to `pbkdf2` tests to prevent a no-DB init race causing SIGSEGV.

Fixes #28.