### PR TITLE
chore: Remove the `deny-warnings` feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -124,7 +124,6 @@ verbose_file_reads = "warn"
 
 [features]
 bench = ["log/release_max_level_info"]
-deny-warnings = []
 disable-encryption = []
 disable-random = []
 gecko = ["mozbuild"]

--- a/tests/aead.rs
+++ b/tests/aead.rs
@@ -4,7 +4,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![warn(clippy::pedantic)]
 #![cfg(not(feature = "disable-encryption"))]
 
 use nss_rs::{

--- a/tests/agent.rs
+++ b/tests/agent.rs
@@ -1,6 +1,3 @@
-#![cfg_attr(feature = "deny-warnings", deny(warnings))]
-#![warn(clippy::pedantic)]
-
 use std::ffi::CStr;
 
 use nss_rs::{


### PR DESCRIPTION
Which really didn't do anything other than make our `cargo-hack` matrix more complex.