### PR TITLE
ci: add SBOM workflow for SSDLC compliance

### DIFF
--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -1,0 +1,15 @@
+name: SBOM
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  sbom:
+    uses: mozilla/actions/.github/workflows/sbom.yml@312d300af3fb2b6551389bf1cb40b10e86294ec2 # v1.1.4
+    permissions:
+      actions: read # Required by anchore/sbom-action to read workflow run context.
+      contents: write # Required to upload the SBOM as a release asset.


### PR DESCRIPTION
Calls the [`sbom.yml`](https://github.com/mozilla/actions/blob/v1.1.4/.github/workflows/sbom.yml)
reusable workflow on every published release, which generates a CycloneDX SBOM
via Mozilla's [`ssdlc-sbom`](https://github.com/mozilla/ssdlc-actions) action
and attaches it to the release as `<tag>.cyclonedx.json`.

Required for SSDLC compliance. The reusable workflow centralises the pinned
`ssdlc-actions` SHA so this repo doesn't need to track it directly.