### PR TITLE
fix: nss-rs doesn't use docker

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,9 +28,6 @@ updates:
       mozilla-actions:
         patterns:
           - "mozilla/actions*"
-      docker-actions:
-        patterns:
-          - "docker/*"
       vm-actions:
         patterns:
           - "vmactions/*"
@@ -42,14 +39,3 @@ updates:
       # semver-patch-days: 5
       exclude:
         - "mozilla/actions*"
-  - package-ecosystem: "docker"
-    directory: "/.github/workflows"
-    schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 99
-    cooldown:
-      default-days: 10
-      # "semver" not supported for docker; see https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#configuration-of-cooldown
-      # semver-major-days: 20
-      # semver-minor-days: 10
-      # semver-patch-days: 5


### PR DESCRIPTION
And Dependabot fails because of that.