### PR TITLE
feat: add Renovate for inline-pinned CI versions

### DIFF
--- a/.github/actions/check-android/action.yml
+++ b/.github/actions/check-android/action.yml
@@ -8,10 +8,6 @@ inputs:
   working-directory:
     description: "Working directory."
     default: "."
-  ndk-version:
-    description: "NDK version to install."
-    # https://searchfox.org/mozilla-central/search?q=NDK_VERSION =&path=python/mozboot/mozboot/android.py
-    default: "27.2.12479018"
   api-level:
     description: "Android API level to use."
     # https://searchfox.org/mozilla-central/search?q=\bapi_level=&path=taskcluster/scripts/misc/build-llvm-common.sh&regexp=true
@@ -27,30 +23,14 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
-      with:
-        distribution: zulu
-        java-version: 23
-
-    - uses: android-actions/setup-android@40fd30fb8d7440372e1316f5d1809ec01dcd3699 # v4.0.1
-      with:
-        accept-android-sdk-licenses: true
-        log-accepted-android-sdk-licenses: false
-
-    - shell: bash
-      env:
-        NDK_VERSION: ${{ inputs.ndk-version }}
-        WD: ${{ inputs.working-directory }}
-      run: cd "$WD" && sdkmanager --install "ndk;$NDK_VERSION"
-
-    - uses: mozilla/actions/rust@7cca521fd0ace71bc6ee830c4a98297023e3402b # v1.1.18
+    - uses: mozilla/actions/rust@c7f9db3409fff64a55f16ac0cacbc4cdd05ae435 # v1.1.19
       with:
         version: stable
         targets: ${{ inputs.target }}
         tools: cargo-ndk@^4, cargo-hack
         token: ${{ inputs.github-token }}
 
-    - uses: mozilla/actions/nss@7cca521fd0ace71bc6ee830c4a98297023e3402b # v1.1.18
+    - uses: mozilla/actions/nss@c7f9db3409fff64a55f16ac0cacbc4cdd05ae435 # v1.1.19
       if: ${{ inputs.minimum-nss-version != '' }}
       with:
         minimum-version: ${{ inputs.minimum-nss-version }}
@@ -101,7 +81,7 @@ runs:
       with:
         api-level: ${{ inputs.api-level }}
         arch: ${{ startsWith(inputs.target, 'x86_64') && 'x86_64' || (startsWith(inputs.target, 'i686') && 'x86' || (startsWith(inputs.target, 'aarch64') && 'arm64-v8a')) }}
-        ndk: ${{ inputs.ndk-version }}
+        ndk: ${{ env.NDK_VERSION }} # Set by mozilla/actions/nss
         emulator-boot-timeout: 120
         disk-size: 2G
         script: /tmp/rust-android-run-tests-on-emulator.sh

--- a/.github/actions/check-vm/action.yml
+++ b/.github/actions/check-vm/action.yml
@@ -33,7 +33,7 @@ runs:
           case "$PLATFORM" in
             freebsd)    pkg update -f && pkg install -y curl llvm nss pkgconf rust-bindgen-cli
                         ;;
-            openbsd)    # TODO: Is there a way to not pin the version of llvm? -z to pkg_add does not work.
+            openbsd)    # renovate: depName=llvm/llvm-project datasource=github-releases
                         pkg_add rust rust-clippy rust-rustfmt rust-bindgen llvm-21.1.8p4 nss # rustup does not support OpenBSD at all
                         ;;
             netbsd)     /usr/sbin/pkg_add pkgin && /usr/pkg/bin/pkgin -y update && /usr/pkg/bin/pkgin -y install curl clang nss pkgconf rust-bindgen cmake ninja                        ;;
@@ -82,7 +82,8 @@ runs:
           # Generate bindings first if requested (before build, so we can bootstrap)
           if [ -n "$BINDGEN_ARGS" ]; then
             # Solaris doesn't have a system package for bindgen
-            [ "$PLATFORM" = "solaris" ] && cargo install bindgen-cli --locked
+            # renovate: depName=bindgen-cli datasource=crate
+            [ "$PLATFORM" = "solaris" ] && cargo install bindgen-cli@0.72.1 --locked
             echo "$BINDGEN_ARGS" | xargs bindgen src/bindings/bsd.h > "$PLATFORM.rs"
             # Compare generated bindings with committed bindings.
             # If different, exit early — there's no point compiling with stale
@@ -102,9 +103,11 @@ runs:
                         ;;
           esac
           cargo fmt --all -- --check
-          cargo install cargo-hack --locked
+          # renovate: depName=cargo-hack datasource=crate
+          cargo install cargo-hack@0.6.45 --locked
           case "$PLATFORM" in
-            freebsd)    cargo install cargo-llvm-cov --locked
+            # renovate: depName=cargo-llvm-cov datasource=crate
+            freebsd)    cargo install cargo-llvm-cov@0.8.7 --locked
                         cargo llvm-cov test --locked --no-fail-fast --codecov --output-path codecov.json
                         ;;
             *)          # FIXME: No profiler support on other platforms, error is: cannot find crate for profiler_builtins

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -212,28 +212,34 @@ jobs:
       matrix:
         include:
           - name: Fedora
-            container: fedora@sha256:498c452f32a739b61f0ef215bce9924ebc4866cbe44710f58157d77723b7a6d2
+            # renovate: depName=fedora datasource=docker
+            container: fedora:42@sha256:498c452f32a739b61f0ef215bce9924ebc4866cbe44710f58157d77723b7a6d2
             install: dnf install -y git nss-devel clang-devel pkgconf-pkg-config gcc curl
           - name: openSUSE Tumbleweed
-            container: opensuse/tumbleweed@sha256:003da6756e3daced6f62ece3d6dc436d21572fb05e558172fc552b6aa1b044ab
+            # renovate: depName=opensuse/tumbleweed datasource=docker
+            container: opensuse/tumbleweed:latest@sha256:003da6756e3daced6f62ece3d6dc436d21572fb05e558172fc552b6aa1b044ab
             install: zypper install -y --no-recommends git mozilla-nss-devel clang-devel pkg-config gcc curl
           - name: Arch Linux
-            container: archlinux@sha256:1047e6e7878d58e4ee47e1cd6459a32fab41246b0efc4109e11b7ef16f50b14d
+            # renovate: depName=archlinux datasource=docker
+            container: archlinux:latest@sha256:1047e6e7878d58e4ee47e1cd6459a32fab41246b0efc4109e11b7ef16f50b14d
             install: pacman -Syu --noconfirm git nss clang pkgconf gcc curl
           - name: Alpine
-            container: alpine@sha256:79ff19e9084a00eece421b2523fb93e22d730e2c0e525905de047e848e56d95f
+            # renovate: depName=alpine datasource=docker
+            container: alpine:latest@sha256:79ff19e9084a00eece421b2523fb93e22d730e2c0e525905de047e848e56d95f
             install: apk add --no-cache git nss-dev clang-dev pkgconf gcc musl-dev curl
             # rustup binaries are statically linked, which prevents bindgen from dlopen-ing libclang.
             # Disabling -crt-static makes them dynamically linked.
             rustflags: "-C target-feature=-crt-static"
           - name: Gentoo
-            container: gentoo/stage3@sha256:ed86fc4f53b75eabefa3eb78fdf7e0db66ca0b3b2eddc4692e16d3d7df94e198
+            # renovate: depName=gentoo/stage3 datasource=docker
+            container: gentoo/stage3:latest@sha256:ed86fc4f53b75eabefa3eb78fdf7e0db66ca0b3b2eddc4692e16d3d7df94e198
             install: >-
               emerge-webrsync -q &&
               emerge -q --getbinpkg --quiet-build=y -1 llvm-core/clang dev-util/pkgconf dev-vcs/git net-misc/curl &&
               ACCEPT_KEYWORDS="~amd64" emerge -q --getbinpkg --quiet-build=y -1 dev-libs/nss
           - name: Slackware
-            container: aclemons/slackware@sha256:f51515e0e9073f0cbd499677c08cd219c2706d6243ad64552a5eba56f42a57fd
+            # renovate: depName=aclemons/slackware datasource=docker
+            container: aclemons/slackware:current-full@sha256:f51515e0e9073f0cbd499677c08cd219c2706d6243ad64552a5eba56f42a57fd
             # current-full ships a complete Slackware installation including all deps
             install: ":"
     defaults:
@@ -278,7 +284,8 @@ jobs:
       - name: Build feature powerset
         run: |
           . "$HOME/.cargo/env"
-          curl --proto '=https' --tlsv1.2 -sSfL https://github.com/cargo-bins/cargo-binstall/releases/latest/download/cargo-binstall-x86_64-unknown-linux-musl.tgz | tar -xzf - -C "$HOME/.cargo/bin"
+          # renovate: depName=cargo-bins/cargo-binstall datasource=github-releases
+          curl --proto '=https' --tlsv1.2 -sSfL https://github.com/cargo-bins/cargo-binstall/releases/download/v1.20.0/cargo-binstall-x86_64-unknown-linux-musl.tgz | tar -xzf - -C "$HOME/.cargo/bin"
           cargo binstall --no-confirm cargo-hack
           cargo hack build --feature-powerset --no-dev-deps --exclude-features gecko --mutually-exclusive-features blapi,disable-encryption
 

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -213,7 +213,7 @@ jobs:
         include:
           - name: Fedora
             # renovate: depName=fedora datasource=docker
-            container: fedora:42@sha256:498c452f32a739b61f0ef215bce9924ebc4866cbe44710f58157d77723b7a6d2
+            container: fedora:latest@sha256:498c452f32a739b61f0ef215bce9924ebc4866cbe44710f58157d77723b7a6d2
             install: dnf install -y git nss-devel clang-devel pkgconf-pkg-config gcc curl
           - name: openSUSE Tumbleweed
             # renovate: depName=opensuse/tumbleweed datasource=docker

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -1,0 +1,27 @@
+name: Renovate
+on:
+  schedule:
+    - cron: "0 0 * * 1" # Weekly on Monday
+  workflow_dispatch:
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
+jobs:
+  renovate:
+    name: Renovate
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    permissions: {} # PAT carries all required permissions; GITHUB_TOKEN is unused
+    steps:
+      - name: Run Renovate
+        run: |
+          docker run --rm \
+            -e RENOVATE_TOKEN \
+            renovate/renovate \
+            mozilla/nss-rs
+        env:
+          RENOVATE_TOKEN: ${{ secrets.RENOVATE }} # zizmor: ignore[secrets-outside-env]

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended"],
+  "prHourlyLimit": 0,
+  "dependencyDashboard": false,
+  "gitAuthor": "Lars Eggert <200328+larseggert@users.noreply.github.com>",
+  "enabledManagers": ["custom.regex"],
+  "customManagers": [
+    {
+      "description": "Pinned versions annotated with '# renovate: depName=X datasource=Y'",
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/\\.github/workflows/.*\\.yml$/",
+        "/action\\.yml$/"
+      ],
+      "matchStrings": [
+        "# renovate: depName=(?<depName>\\S+) datasource=(?<datasource>\\S+)\\n\\s+container:\\s*\\S+?:(?<currentValue>[^@\\s]+)@(?<currentDigest>sha256:[0-9a-f]{64})",
+        "# renovate: depName=(?<depName>\\S+) datasource=(?<datasource>\\S+)\\n[^\\n]*cargo install \\S+?@(?<currentValue>[0-9][0-9.]*)",
+        "# renovate: depName=(?<depName>\\S+) datasource=(?<datasource>\\S+)\\n[^\\n]*llvm-(?<currentValue>[0-9.]+)p[0-9]+",
+        "# renovate: depName=(?<depName>\\S+) datasource=(?<datasource>\\S+)\\n[^\\n]*releases/download/v(?<currentValue>[0-9][0-9.]*)/"
+      ]
+    }
+  ],
+  "packageRules": [
+    {
+      "matchDepNames": ["llvm/llvm-project"],
+      "extractVersion": "^llvmorg-(?<version>\\d+\\.\\d+\\.\\d+)$",
+      "prBodyNotes": [
+        "⚠️ **Manual step**: verify/adjust the OpenBSD package patch suffix (`pN`) in `llvm-{{newVersion}}pN` — it is not tracked upstream and may differ from `p4`."
+      ]
+    },
+    {
+      "matchDepNames": ["cargo-bins/cargo-binstall"],
+      "extractVersion": "^v?(?<version>.+)$"
+    }
+  ]
+}


### PR DESCRIPTION
Track container image digests, cargo install pins, and the OpenBSD LLVM
pin via a custom regex manager mirroring mozilla/actions. Also update
check-android to mozilla/actions v1.1.19, which now owns Android
toolchain setup.