### PR TITLE
fix: track BSD OS releases and fix OpenBSD LLVM datasource

### DIFF
--- a/.github/actions/check-vm/action.yml
+++ b/.github/actions/check-vm/action.yml
@@ -33,7 +33,7 @@ runs:
           case "$PLATFORM" in
             freebsd)    pkg update -f && pkg install -y curl llvm nss pkgconf rust-bindgen-cli
                         ;;
-            openbsd)    # renovate: depName=llvm/llvm-project datasource=github-releases
+            openbsd)    # renovate: depName=llvm datasource=openbsd-packages registryUrl=https://cdn.openbsd.org/pub/OpenBSD/7.9/packages/amd64/
                         pkg_add rust rust-clippy rust-rustfmt rust-bindgen llvm-21.1.8p4 nss # rustup does not support OpenBSD at all
                         ;;
             netbsd)     /usr/sbin/pkg_add pkgin && /usr/pkg/bin/pkgin -y update && /usr/pkg/bin/pkgin -y install curl clang nss pkgconf rust-bindgen cmake ninja                        ;;
@@ -130,6 +130,8 @@ runs:
     - if: ${{ inputs.platform == 'freebsd' }}
       uses: vmactions/freebsd-vm@a6de9343ef5747433d9c25784c90e84998b9d69a # v1.4.6
       with:
+        # renovate: depName=freebsd datasource=freebsd-releases
+        release: "15.0"
         usesh: true
         disable-cache: true
         copyback: true
@@ -140,6 +142,8 @@ runs:
     - if: ${{ inputs.platform == 'openbsd' }}
       uses: vmactions/openbsd-vm@fcf799d7ce9c305ad89eabef1fb2fa5c1c42d0ee # v1.4.3
       with:
+        # renovate: depName=openbsd datasource=openbsd-releases
+        release: "7.9"
         usesh: true
         disable-cache: true
         copyback: true
@@ -150,6 +154,8 @@ runs:
     - if: ${{ inputs.platform == 'netbsd' }}
       uses: vmactions/netbsd-vm@99816dccf75edf233ed6cd00a159e3a5b85ea373 # v1.4.0
       with:
+        # renovate: depName=netbsd datasource=netbsd-releases
+        release: "10.1"
         usesh: true
         disable-cache: true
         copyback: true

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -21,7 +21,9 @@ jobs:
         run: |
           docker run --rm \
             -e RENOVATE_TOKEN \
+            -e RENOVATE_ALLOWED_COMMANDS \
             renovate/renovate \
             mozilla/nss-rs
         env:
           RENOVATE_TOKEN: ${{ secrets.RENOVATE }} # zizmor: ignore[secrets-outside-env]
+          RENOVATE_ALLOWED_COMMANDS: '["^sed -i ''s[|]/OpenBSD/[0-9]+[.][0-9]+/[|]/OpenBSD/[0-9]+[.][0-9]+/[|]g'' [.]github/actions/check-vm/action[.]yml$", "^sed -i ''s[|]/usr/local/llvm[0-9]+/[|]/usr/local/llvm[0-9]+/[|]g'' [.]github/actions/check-vm/action[.]yml$"]'

--- a/renovate.json
+++ b/renovate.json
@@ -1,10 +1,14 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:recommended"],
+  "extends": [
+    "config:recommended"
+  ],
   "prHourlyLimit": 0,
   "dependencyDashboard": false,
   "gitAuthor": "Lars Eggert <200328+larseggert@users.noreply.github.com>",
-  "enabledManagers": ["custom.regex"],
+  "enabledManagers": [
+    "custom.regex"
+  ],
   "customManagers": [
     {
       "description": "Pinned versions annotated with '# renovate: depName=X datasource=Y'",
@@ -16,22 +20,89 @@
       "matchStrings": [
         "# renovate: depName=(?<depName>\\S+) datasource=(?<datasource>\\S+)\\n\\s+container:\\s*\\S+?:(?<currentValue>[^@\\s]+)@(?<currentDigest>sha256:[0-9a-f]{64})",
         "# renovate: depName=(?<depName>\\S+) datasource=(?<datasource>\\S+)\\n[^\\n]*cargo install \\S+?@(?<currentValue>[0-9][0-9.]*)",
-        "# renovate: depName=(?<depName>\\S+) datasource=(?<datasource>\\S+)\\n[^\\n]*llvm-(?<currentValue>[0-9.]+)p[0-9]+",
-        "# renovate: depName=(?<depName>\\S+) datasource=(?<datasource>\\S+)\\n[^\\n]*releases/download/v(?<currentValue>[0-9][0-9.]*)/"
+        "# renovate: depName=(?<depName>\\S+) datasource=(?<datasource>\\S+) registryUrl=(?<registryUrl>\\S+)\\n[^\\n]*llvm-(?<currentValue>[0-9.]+(?:p[0-9]+)?)",
+        "# renovate: depName=(?<depName>\\S+) datasource=(?<datasource>\\S+)\\n[^\\n]*releases/download/v(?<currentValue>[0-9][0-9.]*)/",
+        "# renovate: depName=(?<depName>\\S+) datasource=(?<datasource>\\S+)\\n\\s+release: \"(?<currentValue>[0-9]+\\.[0-9]+)\""
       ]
     }
   ],
   "packageRules": [
     {
-      "matchDepNames": ["llvm/llvm-project"],
-      "extractVersion": "^llvmorg-(?<version>\\d+\\.\\d+\\.\\d+)$",
-      "prBodyNotes": [
-        "⚠️ **Manual step**: verify/adjust the OpenBSD package patch suffix (`pN`) in `llvm-{{newVersion}}pN` — it is not tracked upstream and may differ from `p4`."
-      ]
+      "matchDepNames": [
+        "llvm"
+      ],
+      "versioning": "regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)(?:p(?<build>\\d+))?$",
+      "postUpgradeTasks": {
+        "commands": [
+          "sed -i 's|/usr/local/llvm{{{currentMajor}}}/|/usr/local/llvm{{{newMajor}}}/|g' .github/actions/check-vm/action.yml"
+        ],
+        "fileFilters": [
+          ".github/actions/check-vm/action.yml"
+        ],
+        "executionMode": "update"
+      }
     },
     {
-      "matchDepNames": ["cargo-bins/cargo-binstall"],
+      "matchDepNames": [
+        "cargo-bins/cargo-binstall"
+      ],
       "extractVersion": "^v?(?<version>.+)$"
+    },
+    {
+      "matchDepNames": [
+        "openbsd"
+      ],
+      "versioning": "loose",
+      "postUpgradeTasks": {
+        "commands": [
+          "sed -i 's|/OpenBSD/{{{currentVersion}}}/|/OpenBSD/{{{newVersion}}}/|g' .github/actions/check-vm/action.yml"
+        ],
+        "fileFilters": [
+          ".github/actions/check-vm/action.yml"
+        ],
+        "executionMode": "update"
+      }
+    },
+    {
+      "matchDepNames": [
+        "freebsd"
+      ],
+      "versioning": "loose"
+    },
+    {
+      "matchDepNames": [
+        "netbsd"
+      ],
+      "versioning": "loose"
     }
-  ]
+  ],
+  "customDatasources": {
+    "openbsd-packages": {
+      "format": "html",
+      "transformTemplates": [
+        "{\"releases\": releases[$match(version, /^llvm-\\d+\\.\\d+\\.\\d+(p\\d+)?\\.tgz$/)].{\"version\": $replace($replace(version, /^llvm-/, \"\"), /\\.tgz$/, \"\")}}"
+      ]
+    },
+    "openbsd-releases": {
+      "defaultRegistryUrlTemplate": "https://cdn.openbsd.org/pub/OpenBSD/",
+      "format": "html",
+      "transformTemplates": [
+        "{\"releases\": releases[$match(version, /^\\d+\\.\\d+\\//)].{\"version\": $replace(version, /\\/$/, \"\")}}"
+      ]
+    },
+    "freebsd-releases": {
+      "defaultRegistryUrlTemplate": "https://download.freebsd.org/releases/amd64/amd64/",
+      "format": "html",
+      "transformTemplates": [
+        "{\"releases\": releases[$match(version, /^\\d+[.]\\d+-RELEASE[/]/)].{\"version\": $replace(version, /-RELEASE[/]$/, \"\")}}"
+      ]
+    },
+    "netbsd-releases": {
+      "defaultRegistryUrlTemplate": "https://cdn.netbsd.org/pub/NetBSD/",
+      "format": "html",
+      "transformTemplates": [
+        "{\"releases\": releases[$match(version, /^NetBSD-\\d+[.]\\d+[/]$/)].{\"version\": $replace($replace(version, /^NetBSD-/, \"\"), /[/]$/, \"\")}}"
+      ]
+    }
+  }
 }


### PR DESCRIPTION
Switch LLVM from github-releases to a custom datasource scraping the OpenBSD package mirror for the pinned release, so Renovate only proposes versions that exist there. Add explicit, Renovate-tracked release: pins for OpenBSD, FreeBSD, and NetBSD. Use postUpgradeTasks to automatically update the registryUrl and llvmNN paths when OS or LLVM versions bump.