### PR TITLE
Expose additional TLS_GRP_KEM_* constants

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -119,9 +119,9 @@ exclude = [
 
 [package.metadata.nss]
 # Minimum NSS version required for nss-rs.
-min-version = "3.121"
+min-version = "3.126"
 # SHA256 of the 'nss-<min-version>-with-nspr-<some-version>.tar.gz' release tarball.
-sha256 = "76b9a1364bc4522abc652c4d676498d5062f502f64e38b32e9e2c7a3fff530f1"
+sha256 = "c95a4cf93d6939000642254422d71dffccb5c017d0f40733d3e2be18aa93f1be"
 
 [dependencies]
 enum-map = { version = "2.7", default-features = false }

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -84,6 +84,9 @@ remap_enum! {
         TLS_GRP_EC_X25519 = ssl_grp_ec_curve25519,
         TLS_GRP_KEM_XYBER768D00 = ssl_grp_kem_xyber768d00,
         TLS_GRP_KEM_MLKEM768X25519 = ssl_grp_kem_mlkem768x25519,
+        TLS_GRP_KEM_SECP256R1MLKEM768 = ssl_grp_kem_secp256r1mlkem768,
+        TLS_GRP_KEM_SECP384R1MLKEM1024 = ssl_grp_kem_secp384r1mlkem1024,
+        TLS_GRP_KEM_MLKEM1024 = ssl_grp_kem_mlkem1024,
     }
 }
 


### PR DESCRIPTION
NSS 3.126 has support for draft-ietf-tls-mlkem ([Bug 2019001](https://bugzilla.mozilla.org/show_bug.cgi?id=2019001)). I'm working on Firefox support in [D310120](https://phabricator.services.mozilla.com/D310120) (gated under a pref / enterprise policy). I need a rust alias for `ssl_grp_kem_mlkem1024` in order to advertise ML-KEM-1024 support in h3 ([here](https://searchfox.org/firefox-main/rev/0a7f146ccac85b8f413264042dcd764028d419ec/netwerk/socket/neqo_glue/src/lib.rs#532)).

I'm also adding aliases for the hybrid KEM groups `ssl_grp_kem_secp256r1mlkem768` and `ssl_grp_kem_secp384r1mlkem1024`, which have been supported in NSS for about a year now. I don't expect these to see much use, but we should probably include them in supported groups in TLS and h3.

_edit:_ NSS 3.126 will be released on or about July 16. I don't expect this to get into Firefox 154.