### PR TITLE
fix: Use SQL database format for DB

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -160,7 +160,7 @@ dependencies = [
 
 [[package]]
 name = "nss-rs"
-version = "0.13.4"
+version = "0.14.0"
 dependencies = [
  "bindgen",
  "enum-map",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,7 +99,7 @@ verbose_file_reads = "warn"
 
 [package]
 name = "nss-rs"
-version = "0.13.4"
+version = "0.14.0"
 authors = ["Martin Thomson <mt@lowentropy.net>", "Andy Leiserson <aleiserson@mozilla.com>", "John M. Schanck <jschanck@mozilla.com>", "Benjamin Beurdouche <beurdouche@mozilla.com>", "Anna Weine <anna.weine@mozilla.com>"]
 categories = ["network-programming", "web-programming"]
 keywords = ["nss", "crypto", "mozilla", "firefox"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -154,10 +154,11 @@ fn init_once(db: Option<PathBuf>) -> Res<NssLoaded> {
         }
         let pathstr = path.to_str().ok_or(Error::Internal)?;
         let dircstr = CString::new(pathstr)?;
+        let db_dircstr = CString::new(format!("sql:{pathstr}"))?;
         let empty = CString::new("")?;
         secstatus_to_res(unsafe {
             nss::NSS_Initialize(
-                dircstr.as_ptr(),
+                db_dircstr.as_ptr(),
                 empty.as_ptr(),
                 empty.as_ptr(),
                 nss::SECMOD_DB.as_ptr().cast(),


### PR DESCRIPTION
NSS can operate on two types of databases. The legacy database and a newer SQLite based database. Currently, `init_db` only opens legacy databases. We're starting to use the Rust-based lockstore module very early in Firefox startup, which requires NSS and would like to initialise NSS through that module. This patch allows for that.

If there is a need for the legacy database to still be usable through this binding, we can alternatively let the database kind be passed to `init_db`.