### PR TITLE
chore: Allow `assert_is_empty`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ nursery = { level = "warn", priority = -1 }
 pedantic = { level = "warn", priority = -1 }
 allow_attributes = "warn"
 allow_attributes_without_reason = "allow"
+assert_is_empty = "allow" # We prefer using is_empty() in asserts.
 cfg_not_test = "warn"
 clone_on_ref_ptr = "warn"
 create_dir = "warn"

--- a/src/hp/header_protection_blapi.rs
+++ b/src/hp/header_protection_blapi.rs
@@ -101,7 +101,6 @@ impl Key {
                     )
                 })?;
                 debug_assert_eq!(output_len as usize, output.len());
-                Ok(output)
             }
             Self::Chacha(key_bytes) => {
                 // RFC 9001 §5.4.4: counter = sample[0..4] as little-endian u32,
@@ -124,8 +123,8 @@ impl Key {
                         ctr,
                     )
                 })?;
-                Ok(output)
             }
         }
+        Ok(output)
     }
 }

--- a/src/hp/header_protection_blapi.rs
+++ b/src/hp/header_protection_blapi.rs
@@ -101,6 +101,7 @@ impl Key {
                     )
                 })?;
                 debug_assert_eq!(output_len as usize, output.len());
+                Ok(output)
             }
             Self::Chacha(key_bytes) => {
                 // RFC 9001 §5.4.4: counter = sample[0..4] as little-endian u32,
@@ -123,8 +124,8 @@ impl Key {
                         ctr,
                     )
                 })?;
+                Ok(output)
             }
         }
-        Ok(output)
     }
 }

--- a/tests/agent.rs
+++ b/tests/agent.rs
@@ -36,17 +36,17 @@ fn basic() {
     println!("server {:p}", &server);
 
     let bytes = client.handshake(now(), &[]).expect("send CH");
-    assert_ne!(bytes, []);
+    assert!(!bytes.is_empty());
     assert_eq!(*client.state(), HandshakeState::InProgress);
 
     let bytes = server
         .handshake(now(), &bytes[..])
         .expect("read CH, send SH");
-    assert_ne!(bytes, []);
+    assert!(!bytes.is_empty());
     assert_eq!(*server.state(), HandshakeState::InProgress);
 
     let bytes = client.handshake(now(), &bytes[..]).expect("send CF");
-    assert_eq!(bytes, []);
+    assert!(bytes.is_empty());
     assert_eq!(*client.state(), HandshakeState::AuthenticationPending);
 
     client.authenticated(AuthenticationStatus::Ok);
@@ -54,7 +54,7 @@ fn basic() {
 
     // Calling handshake() again indicates that we're happy with the cert.
     let bytes = client.handshake(now(), &[]).expect("send CF");
-    assert_ne!(bytes, []);
+    assert!(!bytes.is_empty());
     assert!(client.state().is_connected());
 
     let client_info = client.info().expect("got info");
@@ -66,7 +66,7 @@ fn basic() {
     );
 
     let bytes = server.handshake(now(), &bytes[..]).expect("finish");
-    assert_eq!(bytes, []);
+    assert!(bytes.is_empty());
     assert!(server.state().is_connected());
 
     let server_info = server.info().expect("got info");
@@ -136,8 +136,8 @@ fn raw() {
     // The client should have one certificate for the server.
     let certs = client.peer_certificate().unwrap();
     assert_eq!(1, certs.into_iter().count());
-    assert_eq!(certs.stapled_ocsp_responses().unwrap(), [] as [Vec<u8>; 0]);
-    assert_eq!(certs.signed_cert_timestamp().unwrap(), []);
+    assert!(certs.stapled_ocsp_responses().unwrap().is_empty());
+    assert!(certs.signed_cert_timestamp().unwrap().is_empty());
 
     // The server shouldn't have a client certificate.
     assert!(server.peer_certificate().is_none());

--- a/tests/handshake.rs
+++ b/tests/handshake.rs
@@ -137,7 +137,7 @@ impl ZeroRttChecker for PermissiveZeroRttChecker {
         if self.resuming {
             assert_eq!(ZERO_RTT_TOKEN_DATA, token);
         } else {
-            assert_eq!(token, []);
+            assert!(token.is_empty());
         }
         ZeroRttCheckResult::Accept
     }


### PR DESCRIPTION
Alternative to #142, which we revert here.